### PR TITLE
Only include standard C++ headers if the language version is higher than C++14

### DIFF
--- a/include/stx/any.hpp
+++ b/include/stx/any.hpp
@@ -26,7 +26,7 @@
 #endif
 
 #if defined(__has_include) && !defined(STX_NO_STD_ANY)
-#    if __has_include(<any>)
+#    if __has_include(<any>) && (__cplusplus > 201402)
 #       include <any>
         namespace STX_NAMESPACE_NAME {
             using std::any;

--- a/include/stx/optional.hpp
+++ b/include/stx/optional.hpp
@@ -29,7 +29,7 @@
 #endif
 
 #if defined(__has_include) && !defined(STX_NO_STD_OPTIONAL)
-#    if __has_include(<optional>)
+#    if __has_include(<optional>) && (__cplusplus > 201402)
 #       include <optional>
         namespace STX_NAMESPACE_NAME {
             using std::optional;

--- a/include/stx/string_view.hpp
+++ b/include/stx/string_view.hpp
@@ -30,7 +30,7 @@
 #endif
 
 #if defined(__has_include) && !defined(STX_NO_STD_STRING_VIEW)
-#if __has_include(<string_view>)
+#if __has_include(<string_view>) && (__cplusplus > 201402)
         #include <string_view>
         #define STX_HAVE_STD_STRING_VIEW 1
         namespace STX_NAMESPACE_NAME {

--- a/include/stx/variant.hpp
+++ b/include/stx/variant.hpp
@@ -42,7 +42,7 @@
 
 
 #if defined(__has_include) && !defined(STX_NO_STD_VARIANT)
-#    if __has_include(<variant>)
+#    if __has_include(<variant>) && (__cplusplus > 201402)
         namespace STX_NAMESPACE_NAME {
             using std::variant;
             using std::visit;


### PR DESCRIPTION
Only checking if the system has the include file is not enough. Since GCC 7.1, header files <string_view>, <variant>, <any> and <optional> are available for inclusion, but triggers an error if not in C++17 mode:
```
/usr/include/c++/7.1.1/bits/c++17_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2017 standard. This support must be enabled with the -std=c++17 or -std=gnu++17 compiler options.
```
As we can see in <string_view>, This error is only enabled with C++14 and lower (comment mine):
```c++
#if __cplusplus <= 201402L
# include <bits/c++17_warning.h> // contains the error
#else
``` 
