### PR TITLE
Update std::experimental::optional check on Apple systems

### DIFF
--- a/include/stx/optional.hpp
+++ b/include/stx/optional.hpp
@@ -18,7 +18,7 @@
 #if !defined(STX_NO_STD_OPTIONAL) && defined(__APPLE__)
 // This header is empty on C++ but defines _LIBCPP_VERSION for us
 #include <ciso646>
-#if defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION <= 3800)
+#if defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION <= 4000)
 #define STX_NO_STD_OPTIONAL
 #endif // _LIBCPP_VERSION
 #endif // __APPLE__


### PR DESCRIPTION
(Thanks for such a useful library!)

It turns out that Xcode 9 still has the missing symbol in the dynamic library as noted in 3b42609d0d2abd90a605f9cdbd1354e08b6d7464.

We increase the version cutoff to blacklist 3.9 and 4.0 as well.

This is an updated fix for issue #5.

See RobotLocomotion/drake#7022 as the origin of this patch.