### PR TITLE
Merge up optional has_value() and reset() from akrzemi1

### DIFF
--- a/include/stx/optional.hpp
+++ b/include/stx/optional.hpp
@@ -570,6 +570,7 @@ public:
   // 20.5.4.5, Observers
   
   explicit constexpr operator bool() const noexcept { return initialized(); }
+  constexpr bool has_value() const noexcept { return initialized(); }
   
   constexpr T const* operator ->() const {
     return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
@@ -763,6 +764,10 @@ public:
   }
   
   explicit constexpr operator bool() const noexcept {
+    return ref != nullptr;
+  }
+ 
+  constexpr bool has_value() const noexcept {
     return ref != nullptr;
   }
   

--- a/include/stx/optional.hpp
+++ b/include/stx/optional.hpp
@@ -672,6 +672,8 @@ public:
 
 # endif
 
+  // 20.6.3.6, modifiers
+  void reset() noexcept { clear(); }
 };
 
 
@@ -776,6 +778,9 @@ public:
   {
     return *this ? **this : detail_::convert<typename std::decay<T>::type>(constexpr_forward<V>(v));
   }
+
+  // x.x.x.x, modifiers
+  void reset() noexcept { ref = nullptr; }
 };
 
 

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -698,6 +698,19 @@ TEST(value_or)
   assert (os.value_or("BBB") == "BBB");
 };
 
+TEST(reset)
+{
+  using namespace std::experimental;
+  optional<int> oi {1};
+  oi.reset();
+  assert (!oi);
+
+  int i = 1;
+  optional<const int&> oir {i};
+  oir.reset();
+  assert (!oir);
+};
+
 TEST(mixed_order)
 {
   using namespace stx;


### PR DESCRIPTION
Closes #13.

This PR just cherry-picks the two commits from https://github.com/akrzemi1/Optional, unchanged.
