### PR TITLE
Fix duplicate definition of stx::in_place and related

### DIFF
--- a/include/stx/optional.hpp
+++ b/include/stx/optional.hpp
@@ -37,8 +37,11 @@
             using std::nullopt_t;
             using std::nullopt;
             using std::make_optional;
+#       ifndef STX_HAVE_IN_PLACE_T
             using std::in_place_t;
             using std::in_place;
+#       define STX_HAVE_IN_PLACE_T 1
+#       endif // STX_HAVE_IN_PLACE_T
         }
 #       define STX_HAVE_STD_OPTIONAL 1
 #   elif __has_include(<experimental/optional>)
@@ -49,8 +52,11 @@
             using std::experimental::nullopt_t;
             using std::experimental::nullopt;
             using std::experimental::make_optional;
+#       ifndef STX_HAVE_IN_PLACE_T
             using std::experimental::in_place_t;
             using std::experimental::in_place;
+#       define STX_HAVE_IN_PLACE_T 1
+#       endif // STX_HAVE_IN_PLACE_T
         }
 #       define STX_HAVE_STD_OPTIONAL 1
 #    endif // __hasinclude(optional)
@@ -298,24 +304,6 @@ struct in_place_t {
 };
 
 constexpr in_place_t in_place{};
-
-template <class T> struct in_place_type_t {
-    explicit in_place_type_t() = default;
-};
-
-
-template <size_t I> struct in_place_index_t {
-    explicit in_place_index_t() = default;
-};
-
-
-#if __cpp_variable_templates >= 201304
-template <class T>
-constexpr in_place_type_t<T> in_place_type{};
-template <size_t I>
-constexpr in_place_index_t<I> in_place_index{};
-#endif // __cpp_variable_templates
-
 
 #define STX_HAVE_IN_PLACE_T
 #endif // STX_HAVE_IN_PLACE_T

--- a/include/stx/variant.hpp
+++ b/include/stx/variant.hpp
@@ -57,7 +57,7 @@
 #           ifndef STX_HAVE_IN_PLACE_T
             using std::in_place_t;
             using std::in_place;
-#           define STX_IN_PLACE_T 1
+#           define STX_HAVE_IN_PLACE_T 1
 #           endif
             using std::in_place_type_t;
             using std::in_place_type;


### PR DESCRIPTION
Closes #4.

In some cases, `optional.hpp` and `variant.hpp` still could not be included
in the same translation unit:

(1) If the user included `variant.hpp` first and `optional.hpp` second and
if `<variant>` was available, we'd see duplicate `inplace_t` and `inplace`.

(2) If the user included `optional.hpp` first and `variant.hpp` second and
if `<optional>` was available, we'd see duplicate `inplace_t` and `inplace`.

(3) If the user included `optional.hpp` first and `variant.hpp` second and
if `<optional>` was not available, we'd see duplicate `in_place_type_t`,
`in_place_type`, `in_place_index_t`, and `in_place_index`.

This improves on 6da04dc9898a2bc1724575b339d983b053d20d4f.

This is similar to the fix proposed in #8, but goes a step further and removes the `in_place_type_t` and `in_place_index_t` from `optional.hpp` -- they are not related to using optional (only variant and any), and when we're using `<optional>` or `<experimental/optional>` they were not being aliased anyway, so they were only conditionally provided by stx.  It seemed better to remove them, instead of trying to make them play nice with variant.hpp.